### PR TITLE
Dockerize go-ssb-room

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ RUN apk del \
       build-base \
       git
 
+RUN chmod +x ./start.sh
 CMD ./start.sh

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,38 @@
+# Creates a slimmer image than the default Dockerfile
+# that only holds what's absolutely necessary to run it.
+
+FROM golang:1.17-alpine AS build
+RUN apk add --no-cache \
+      build-base \
+      git \
+      sqlite \
+      sqlite-dev
+
+RUN mkdir /app
+WORKDIR /app
+COPY . /app
+
+RUN cd /app/cmd/server && go build && \
+    cd /app/cmd/insert-user && go build
+
+FROM alpine AS deploy
+RUN apk add --no-cache \
+      sqlite \
+      sqlite-dev
+
+RUN mkdir /app
+COPY --from=build /app/cmd /app/cmd
+COPY --from=build /app/start.sh /app/start.sh
+
+EXPOSE 8008
+EXPOSE 3000
+
+RUN chmod 777 /app/start.sh
+# TODO don't do this. chmod 777 is an anti-pattern and risky security-wise.
+# We need to create an app user and group, and then ensure the
+# docker-compose file is being run with this same group.
+# If the user is not set correctly, and start.sh is at lesser permissions,
+# then the docker file will not run.
+# This is a temporary solution to ensure our docker image can run.
+
+CMD /app/start.sh

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2021 The NGI Pointer Secure-Scuttlebutt Team of 2020/2021
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[[ -f ".env" ]] && source .env
+./cmd/server/server -https-domain="${HTTPS_DOMAIN}" -repo="${REPO:-~/.ssb-go-room-secrets}" -aliases-as-subdomains="${ALIASES_AS_SUBDOMAINS}"

--- a/start.sh
+++ b/start.sh
@@ -4,5 +4,5 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-# we use relative paths so this file can run easily within a docker container
+# we use absolute paths so this file can run easily within a docker container
 /app/cmd/server/server -https-domain="${HTTPS_DOMAIN}" -repo="${REPO:-/ssb-go-room-secrets}" -aliases-as-subdomains="${ALIASES_AS_SUBDOMAINS}"

--- a/start.sh
+++ b/start.sh
@@ -4,5 +4,5 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-[[ -f ".env" ]] && source .env
-./cmd/server/server -https-domain="${HTTPS_DOMAIN}" -repo="${REPO:-~/.ssb-go-room-secrets}" -aliases-as-subdomains="${ALIASES_AS_SUBDOMAINS}"
+# we use relative paths so this file can run easily within a docker container
+/app/cmd/server/server -https-domain="${HTTPS_DOMAIN}" -repo="${REPO:-/ssb-go-room-secrets}" -aliases-as-subdomains="${ALIASES_AS_SUBDOMAINS}"


### PR DESCRIPTION
This pr would add a Dockerfile for building go-ssb-room as a docker image, for use in the ansible scripts.

As part of the ansible compatability, it adds a -password flag to the insert-user command, so that you can add new users non-interactively in our ansible scripts. 