### PR TITLE
adjust newMember var to use known pattern

### DIFF
--- a/roomdb/sqlite/invites_test.go
+++ b/roomdb/sqlite/invites_test.go
@@ -165,7 +165,10 @@ func TestInvites_BypassInvitestToken(t *testing.T) {
 	tr := repo.New(testRepo)
 
 	// fake feed for testing, looks ok at least
-	newMember := refs.FeedRef{ID: bytes.Repeat([]byte("acab"), 8), Algo: refs.RefAlgoFeedSSB1}
+	newMember, err := refs.NewFeedRefFromBytes(bytes.Repeat([]byte("acab"), 8), refs.RefAlgoFeedSSB1)
+	if err != nil {
+		t.Error(err)
+	}
 
 	token := "magic token"
 


### PR DESCRIPTION
Our automated build step currently breaks on this test.  Looking at the other tests in this file that also use newMember, it looks like they're using a slightly different call, that does not specify ID and Algo (as these are what's causing the error).