### PR TITLE
Add github action for building/pushing images

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,44 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=stable
+            type=sha,enable=true,prefix={{date 'YYYYMMDD'}}_sha-,format=short
+            type=ref,event=branch
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This adds a starting point for the automatic building and pushing of images to a docker repository.

With this change, whenever a new commit is pushed to the master branch, github will build a new image from the code in master, and tag it with:
- stable
- $DATE_$COMMIT_HASH
- master

It will then push this image to the cooldracula repository.

We can improve this flow in a few ways, like only tagging it stable on a git tagged release, and pushing to the planetary-social docker repository instead.  Both of these are administrative, though, and I wanted to show an example flow first.